### PR TITLE
feat(US-A02): Category management CRUD

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,11 +1,327 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+
+interface Category {
+  id: string;
+  name: string;
+  weight: number;
+}
+
 export default function AdminPage() {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [newName, setNewName] = useState('');
+  const [newWeight, setNewWeight] = useState<number>(0);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState('');
+  const [editWeight, setEditWeight] = useState<number>(0);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  function getKey() {
+    return new URLSearchParams(window.location.search).get('key') ?? '';
+  }
+
+  const loadCategories = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/admin/categories?key=${encodeURIComponent(getKey())}`);
+      if (res.ok) {
+        const data = await res.json();
+        setCategories(data.categories);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadCategories();
+  }, [loadCategories]);
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    const key = getKey();
+
+    const res = await fetch(`/api/admin/categories?key=${encodeURIComponent(key)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: newName.trim(), weight: newWeight }),
+    });
+
+    if (!res.ok) {
+      const data = await res.json();
+      setError(data.error || 'Failed to add category');
+      return;
+    }
+
+    const data = await res.json();
+    setCategories(data.categories);
+    setNewName('');
+    setNewWeight(0);
+  }
+
+  async function handleDelete(id: string) {
+    setError('');
+    const key = getKey();
+    const res = await fetch(
+      `/api/admin/categories?key=${encodeURIComponent(key)}&id=${encodeURIComponent(id)}`,
+      { method: 'DELETE' }
+    );
+
+    if (!res.ok) {
+      const data = await res.json();
+      setError(data.error || 'Failed to delete');
+      return;
+    }
+
+    const data = await res.json();
+    setCategories(data.categories);
+  }
+
+  async function handleUpdate(id: string) {
+    setError('');
+    const key = getKey();
+
+    const res = await fetch(`/api/admin/categories?key=${encodeURIComponent(key)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, name: editName.trim(), weight: editWeight }),
+    });
+
+    if (!res.ok) {
+      const data = await res.json();
+      setError(data.error || 'Failed to update');
+      return;
+    }
+
+    const data = await res.json();
+    setCategories(data.categories);
+    setEditingId(null);
+  }
+
+  const totalWeight = categories.reduce((sum, c) => sum + c.weight, 0);
+
   return (
-    <div style={{ padding: '2rem', fontFamily: 'system-ui, sans-serif' }}>
-      <h1>Admin Dashboard</h1>
-      <p>You are authenticated as admin.</p>
-      <p>
-        <a href="/admin/create">Create new event</a>
-      </p>
+    <div style={styles.container}>
+      <h1 style={styles.heading}>Admin Dashboard</h1>
+
+      <section style={styles.section}>
+        <h2 style={styles.subheading}>
+          Categories
+          <span style={{
+            ...styles.badge,
+            background: totalWeight === 100 ? '#198754' : '#dc3545',
+          }}>
+            Weight: {totalWeight}/100
+          </span>
+        </h2>
+
+        {loading ? (
+          <p>Loading…</p>
+        ) : categories.length === 0 ? (
+          <p style={styles.muted}>No categories yet. Add one below.</p>
+        ) : (
+          <table style={styles.table}>
+            <thead>
+              <tr>
+                <th style={styles.th}>Name</th>
+                <th style={{ ...styles.th, width: 80 }}>Weight</th>
+                <th style={{ ...styles.th, width: 140 }}>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {categories.map((cat) => (
+                <tr key={cat.id}>
+                  {editingId === cat.id ? (
+                    <>
+                      <td style={styles.td}>
+                        <input
+                          value={editName}
+                          onChange={(e) => setEditName(e.target.value)}
+                          style={styles.inputSmall}
+                        />
+                      </td>
+                      <td style={styles.td}>
+                        <input
+                          type="number"
+                          value={editWeight}
+                          onChange={(e) => setEditWeight(Number(e.target.value))}
+                          min={0}
+                          max={100}
+                          style={{ ...styles.inputSmall, width: 60 }}
+                        />
+                      </td>
+                      <td style={styles.td}>
+                        <button style={styles.btnSave} onClick={() => handleUpdate(cat.id)}>
+                          Save
+                        </button>
+                        <button style={styles.btnCancel} onClick={() => setEditingId(null)}>
+                          Cancel
+                        </button>
+                      </td>
+                    </>
+                  ) : (
+                    <>
+                      <td style={styles.td}>{cat.name}</td>
+                      <td style={styles.td}>{cat.weight}</td>
+                      <td style={styles.td}>
+                        <button
+                          style={styles.btnEdit}
+                          onClick={() => {
+                            setEditingId(cat.id);
+                            setEditName(cat.name);
+                            setEditWeight(cat.weight);
+                          }}
+                        >
+                          Edit
+                        </button>
+                        <button style={styles.btnDelete} onClick={() => handleDelete(cat.id)}>
+                          Delete
+                        </button>
+                      </td>
+                    </>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {error && <p style={styles.error}>{error}</p>}
+
+        <form onSubmit={handleAdd} style={styles.addForm}>
+          <input
+            type="text"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            placeholder="Category name"
+            required
+            style={styles.input}
+          />
+          <input
+            type="number"
+            value={newWeight}
+            onChange={(e) => setNewWeight(Number(e.target.value))}
+            min={0}
+            max={100}
+            placeholder="Weight"
+            style={{ ...styles.input, width: 80 }}
+          />
+          <button type="submit" style={styles.btnAdd} disabled={!newName.trim()}>
+            Add
+          </button>
+        </form>
+      </section>
     </div>
   );
 }
+
+const styles: Record<string, React.CSSProperties> = {
+  container: {
+    maxWidth: 700,
+    margin: '2rem auto',
+    padding: '2rem',
+    fontFamily: 'system-ui, sans-serif',
+  },
+  heading: { marginBottom: '1.5rem' },
+  subheading: {
+    fontSize: '1.2rem',
+    marginBottom: '1rem',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0.75rem',
+  },
+  section: { marginBottom: '2rem' },
+  badge: {
+    fontSize: '0.75rem',
+    color: '#fff',
+    padding: '0.2rem 0.5rem',
+    borderRadius: 4,
+    fontWeight: 'normal',
+  },
+  muted: { color: '#888' },
+  table: {
+    width: '100%',
+    borderCollapse: 'collapse',
+    marginBottom: '1rem',
+  },
+  th: {
+    textAlign: 'left',
+    borderBottom: '2px solid #dee2e6',
+    padding: '0.5rem',
+    fontSize: '0.85rem',
+    color: '#555',
+  },
+  td: {
+    padding: '0.5rem',
+    borderBottom: '1px solid #eee',
+    verticalAlign: 'middle',
+  },
+  addForm: {
+    display: 'flex',
+    gap: '0.5rem',
+    alignItems: 'center',
+  },
+  input: {
+    padding: '0.4rem 0.5rem',
+    fontSize: '0.9rem',
+    border: '1px solid #ccc',
+    borderRadius: 4,
+  },
+  inputSmall: {
+    padding: '0.3rem 0.4rem',
+    fontSize: '0.85rem',
+    border: '1px solid #ccc',
+    borderRadius: 4,
+    width: '100%',
+  },
+  btnAdd: {
+    padding: '0.4rem 1rem',
+    background: '#0070f3',
+    color: '#fff',
+    border: 'none',
+    borderRadius: 4,
+    cursor: 'pointer',
+    fontSize: '0.9rem',
+  },
+  btnEdit: {
+    padding: '0.2rem 0.5rem',
+    background: '#e9ecef',
+    border: '1px solid #ccc',
+    borderRadius: 4,
+    cursor: 'pointer',
+    fontSize: '0.8rem',
+    marginRight: '0.3rem',
+  },
+  btnDelete: {
+    padding: '0.2rem 0.5rem',
+    background: '#f8d7da',
+    color: '#842029',
+    border: '1px solid #f5c2c7',
+    borderRadius: 4,
+    cursor: 'pointer',
+    fontSize: '0.8rem',
+  },
+  btnSave: {
+    padding: '0.2rem 0.5rem',
+    background: '#198754',
+    color: '#fff',
+    border: 'none',
+    borderRadius: 4,
+    cursor: 'pointer',
+    fontSize: '0.8rem',
+    marginRight: '0.3rem',
+  },
+  btnCancel: {
+    padding: '0.2rem 0.5rem',
+    background: '#e9ecef',
+    border: '1px solid #ccc',
+    borderRadius: 4,
+    cursor: 'pointer',
+    fontSize: '0.8rem',
+  },
+  error: { color: '#e00', margin: '0.5rem 0' },
+};

--- a/app/api/admin/categories/route.ts
+++ b/app/api/admin/categories/route.ts
@@ -1,0 +1,153 @@
+import { NextRequest, NextResponse } from 'next/server';
+import crypto from 'crypto';
+import { loadEvent, updateEvent } from '@/lib/store';
+import { validateAdminKey } from '@/lib/auth';
+import type { Category } from '@/lib/types';
+import { isCategory } from '@/lib/types';
+
+/**
+ * GET /api/admin/categories?key=...
+ * List all categories for the current event.
+ */
+export async function GET(request: NextRequest) {
+  const key = request.nextUrl.searchParams.get('key');
+  if (!validateAdminKey(key)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const event = loadEvent();
+  if (!event) {
+    return NextResponse.json({ error: 'No event found' }, { status: 404 });
+  }
+
+  return NextResponse.json({ categories: event.categories ?? [] });
+}
+
+/**
+ * POST /api/admin/categories?key=...
+ * Add a new category. Body: { name: string, weight: number }
+ */
+export async function POST(request: NextRequest) {
+  const key = request.nextUrl.searchParams.get('key');
+  if (!validateAdminKey(key)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const event = loadEvent();
+  if (!event) {
+    return NextResponse.json({ error: 'No event found' }, { status: 404 });
+  }
+
+  const body = await request.json();
+  const name = typeof body?.name === 'string' ? body.name.trim() : '';
+  const weight = typeof body?.weight === 'number' ? body.weight : -1;
+
+  if (!name) {
+    return NextResponse.json({ error: 'Category name is required' }, { status: 400 });
+  }
+  if (weight < 0 || weight > 100) {
+    return NextResponse.json({ error: 'Weight must be between 0 and 100' }, { status: 400 });
+  }
+
+  // Check for duplicate name
+  const categories = event.categories ?? [];
+  if (categories.some((c) => c.name.toLowerCase() === name.toLowerCase())) {
+    return NextResponse.json({ error: 'Category name already exists' }, { status: 409 });
+  }
+
+  const newCategory: Category = {
+    id: crypto.randomUUID(),
+    name,
+    weight,
+  };
+
+  const updated = updateEvent({
+    categories: [...categories, newCategory],
+  });
+
+  return NextResponse.json(
+    { category: newCategory, categories: updated.categories },
+    { status: 201 }
+  );
+}
+
+/**
+ * DELETE /api/admin/categories?key=...&id=...
+ * Remove a category by ID.
+ */
+export async function DELETE(request: NextRequest) {
+  const key = request.nextUrl.searchParams.get('key');
+  if (!validateAdminKey(key)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const event = loadEvent();
+  if (!event) {
+    return NextResponse.json({ error: 'No event found' }, { status: 404 });
+  }
+
+  const categoryId = request.nextUrl.searchParams.get('id');
+  if (!categoryId) {
+    return NextResponse.json({ error: 'Category id is required' }, { status: 400 });
+  }
+
+  const categories = event.categories ?? [];
+  const filtered = categories.filter((c) => c.id !== categoryId);
+
+  if (filtered.length === categories.length) {
+    return NextResponse.json({ error: 'Category not found' }, { status: 404 });
+  }
+
+  const updated = updateEvent({ categories: filtered });
+  return NextResponse.json({ categories: updated.categories });
+}
+
+/**
+ * PUT /api/admin/categories?key=...
+ * Update an existing category. Body: { id: string, name?: string, weight?: number }
+ */
+export async function PUT(request: NextRequest) {
+  const key = request.nextUrl.searchParams.get('key');
+  if (!validateAdminKey(key)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const event = loadEvent();
+  if (!event) {
+    return NextResponse.json({ error: 'No event found' }, { status: 404 });
+  }
+
+  const body = await request.json();
+  const id = typeof body?.id === 'string' ? body.id : '';
+  if (!id) {
+    return NextResponse.json({ error: 'Category id is required' }, { status: 400 });
+  }
+
+  const categories = event.categories ?? [];
+  const idx = categories.findIndex((c) => c.id === id);
+  if (idx === -1) {
+    return NextResponse.json({ error: 'Category not found' }, { status: 404 });
+  }
+
+  const existing = categories[idx];
+  const name = typeof body?.name === 'string' ? body.name.trim() : existing.name;
+  const weight = typeof body?.weight === 'number' ? body.weight : existing.weight;
+
+  if (!name) {
+    return NextResponse.json({ error: 'Category name cannot be empty' }, { status: 400 });
+  }
+  if (weight < 0 || weight > 100) {
+    return NextResponse.json({ error: 'Weight must be between 0 and 100' }, { status: 400 });
+  }
+
+  // Check duplicate name (excluding self)
+  if (categories.some((c, i) => i !== idx && c.name.toLowerCase() === name.toLowerCase())) {
+    return NextResponse.json({ error: 'Category name already exists' }, { status: 409 });
+  }
+
+  const updatedCategories = [...categories];
+  updatedCategories[idx] = { id, name, weight };
+
+  const updated = updateEvent({ categories: updatedCategories });
+  return NextResponse.json({ category: updatedCategories[idx], categories: updated.categories });
+}

--- a/app/api/admin/create-event/route.ts
+++ b/app/api/admin/create-event/route.ts
@@ -69,6 +69,7 @@ export async function POST(request: NextRequest) {
         J2: generateKey(),
         J3: generateKey(),
       },
+      categories: [],
     };
 
     saveEvent(event);

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -63,6 +63,20 @@ export function loadEvent(): EventData | null {
 }
 
 /**
+ * Partially update the event (merge with existing data).
+ * Useful for adding/removing categories without regenerating keys.
+ */
+export function updateEvent(patch: Partial<EventData>): EventData {
+  const existing = loadEvent();
+  if (!existing) {
+    throw new Error('No event exists to update');
+  }
+  const updated: EventData = { ...existing, ...patch };
+  saveEvent(updated);
+  return updated;
+}
+
+/**
  * Save event with atomic write (temp file → rename).
  * Ensures data is never corrupted if process crashes mid-write.
  * Throws if validation fails or I/O fails.


### PR DESCRIPTION
## US-A02 - Category Management

### Changes
- lib/types.ts: Added Category interface and isCategory() type guard
- lib/store.ts: Added updateEvent() for partial updates
- app/api/admin/categories/route.ts (new): Full CRUD with admin key guard
- app/admin/page.tsx: Category table with inline editing and weight-sum badge
- app/api/admin/create-event/route.ts: Seeds new events with categories: []

### Testing
All scenarios passed: auth guard (401), add/delete/update categories, duplicate rejection, clean build.
