### PR TITLE
feat(US-A05): Live controls for admin

### DIFF
--- a/app/admin/live/page.tsx
+++ b/app/admin/live/page.tsx
@@ -1,0 +1,267 @@
+'use client';
+
+import { useEffect, useState, useCallback, Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+interface CategorySummary {
+  id: string;
+  name: string;
+  athleteCount: number;
+}
+
+interface Athlete {
+  bib: number;
+  name: string;
+}
+
+interface ActiveCategory {
+  id: string;
+  name: string;
+  athletes: Athlete[];
+}
+
+interface LiveState {
+  activeCategoryId: string | null;
+  activeRun: 1 | 2;
+  activeAthleteIndex: number;
+}
+
+export default function LiveControlPage() {
+  return (
+    <Suspense fallback={<main style={{ padding: '2rem', fontFamily: 'system-ui, sans-serif' }}><p>Loading…</p></main>}>
+      <LiveControlInner />
+    </Suspense>
+  );
+}
+
+function LiveControlInner() {
+  const searchParams = useSearchParams();
+  const key = searchParams.get('key') ?? '';
+
+  const [categories, setCategories] = useState<CategorySummary[]>([]);
+  const [activeCategory, setActiveCategory] = useState<ActiveCategory | null>(null);
+  const [liveState, setLiveState] = useState<LiveState>({
+    activeCategoryId: null,
+    activeRun: 1,
+    activeAthleteIndex: 0,
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const fetchLive = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/admin/live?key=${encodeURIComponent(key)}`);
+      if (!res.ok) throw new Error('Failed to load live state');
+      const data = await res.json();
+      setLiveState(data.liveState);
+      setCategories(data.categories);
+      setActiveCategory(data.activeCategory);
+      setError('');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  }, [key]);
+
+  useEffect(() => {
+    fetchLive();
+  }, [fetchLive]);
+
+  const updateLive = async (patch: Partial<LiveState>) => {
+    try {
+      const res = await fetch(`/api/admin/live?key=${encodeURIComponent(key)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch),
+      });
+      if (!res.ok) throw new Error('Failed to update live state');
+      // Refetch to get derived active category
+      await fetchLive();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
+    }
+  };
+
+  const handleCategoryChange = (categoryId: string) => {
+    const value = categoryId || null;
+    updateLive({ activeCategoryId: value });
+  };
+
+  const handleRunChange = (run: 1 | 2) => {
+    updateLive({ activeRun: run });
+  };
+
+  const handlePrev = () => {
+    if (liveState.activeAthleteIndex > 0) {
+      updateLive({ activeAthleteIndex: liveState.activeAthleteIndex - 1 });
+    }
+  };
+
+  const handleNext = () => {
+    const count = activeCategory?.athletes.length ?? 0;
+    if (liveState.activeAthleteIndex < count - 1) {
+      updateLive({ activeAthleteIndex: liveState.activeAthleteIndex + 1 });
+    }
+  };
+
+  const handleSelectAthlete = (index: number) => {
+    updateLive({ activeAthleteIndex: index });
+  };
+
+  if (loading) {
+    return (
+      <main style={{ padding: '2rem', fontFamily: 'system-ui, sans-serif' }}>
+        <p>Loading live controls…</p>
+      </main>
+    );
+  }
+
+  const athletes = activeCategory?.athletes ?? [];
+  const currentAthlete = athletes[liveState.activeAthleteIndex] ?? null;
+
+  return (
+    <main style={{ padding: '2rem', fontFamily: 'system-ui, sans-serif', maxWidth: 700, margin: '0 auto' }}>
+      <h1 style={{ marginBottom: '1.5rem' }}>Live Controls</h1>
+
+      {error && (
+        <div style={{ color: '#b91c1c', background: '#fef2f2', padding: '0.75rem', borderRadius: 6, marginBottom: '1rem' }}>
+          {error}
+        </div>
+      )}
+
+      {/* Category selector */}
+      <section style={{ marginBottom: '1.5rem' }}>
+        <label style={{ fontWeight: 600, display: 'block', marginBottom: '0.5rem' }}>Active Category</label>
+        <select
+          value={liveState.activeCategoryId ?? ''}
+          onChange={(e) => handleCategoryChange(e.target.value)}
+          style={{ width: '100%', padding: '0.5rem', fontSize: '1rem', borderRadius: 4, border: '1px solid #ccc' }}
+        >
+          <option value="">— none —</option>
+          {categories.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name} ({c.athleteCount} athletes)
+            </option>
+          ))}
+        </select>
+      </section>
+
+      {/* Run selector */}
+      <section style={{ marginBottom: '1.5rem' }}>
+        <label style={{ fontWeight: 600, display: 'block', marginBottom: '0.5rem' }}>Active Run</label>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          {([1, 2] as const).map((run) => (
+            <button
+              key={run}
+              onClick={() => handleRunChange(run)}
+              style={{
+                flex: 1,
+                padding: '0.5rem 1rem',
+                fontSize: '1rem',
+                border: '2px solid',
+                borderColor: liveState.activeRun === run ? '#2563eb' : '#ccc',
+                backgroundColor: liveState.activeRun === run ? '#2563eb' : '#fff',
+                color: liveState.activeRun === run ? '#fff' : '#333',
+                borderRadius: 4,
+                cursor: 'pointer',
+                fontWeight: liveState.activeRun === run ? 700 : 400,
+              }}
+            >
+              Run {run}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      {/* Active rider display */}
+      {activeCategory && (
+        <section style={{ marginBottom: '1.5rem' }}>
+          <label style={{ fontWeight: 600, display: 'block', marginBottom: '0.5rem' }}>
+            Active Rider {athletes.length > 0 ? `(${liveState.activeAthleteIndex + 1} / ${athletes.length})` : '(0 / 0)'}
+          </label>
+
+          {currentAthlete ? (
+            <div
+              style={{
+                padding: '1rem',
+                background: '#eff6ff',
+                border: '2px solid #2563eb',
+                borderRadius: 6,
+                fontSize: '1.25rem',
+                fontWeight: 700,
+                textAlign: 'center',
+                marginBottom: '0.75rem',
+              }}
+            >
+              #{currentAthlete.bib} — {currentAthlete.name}
+            </div>
+          ) : (
+            <div style={{ color: '#6b7280', marginBottom: '0.75rem' }}>No athletes in this category.</div>
+          )}
+
+          {/* Prev / Next */}
+          <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+            <button
+              onClick={handlePrev}
+              disabled={liveState.activeAthleteIndex <= 0}
+              style={{
+                flex: 1,
+                padding: '0.5rem',
+                fontSize: '1rem',
+                border: '1px solid #ccc',
+                borderRadius: 4,
+                cursor: liveState.activeAthleteIndex <= 0 ? 'not-allowed' : 'pointer',
+                opacity: liveState.activeAthleteIndex <= 0 ? 0.4 : 1,
+              }}
+            >
+              ◀ Previous
+            </button>
+            <button
+              onClick={handleNext}
+              disabled={liveState.activeAthleteIndex >= athletes.length - 1}
+              style={{
+                flex: 1,
+                padding: '0.5rem',
+                fontSize: '1rem',
+                border: '1px solid #ccc',
+                borderRadius: 4,
+                cursor: liveState.activeAthleteIndex >= athletes.length - 1 ? 'not-allowed' : 'pointer',
+                opacity: liveState.activeAthleteIndex >= athletes.length - 1 ? 0.4 : 1,
+              }}
+            >
+              Next ▶
+            </button>
+          </div>
+
+          {/* Athlete list */}
+          <label style={{ fontWeight: 600, display: 'block', marginBottom: '0.5rem' }}>Rider List</label>
+          <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+            {athletes.map((a, idx) => (
+              <li
+                key={a.bib}
+                onClick={() => handleSelectAthlete(idx)}
+                style={{
+                  padding: '0.5rem 0.75rem',
+                  borderBottom: '1px solid #e5e7eb',
+                  cursor: 'pointer',
+                  backgroundColor: idx === liveState.activeAthleteIndex ? '#dbeafe' : 'transparent',
+                  fontWeight: idx === liveState.activeAthleteIndex ? 700 : 400,
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                }}
+              >
+                <span>#{a.bib} — {a.name}</span>
+                {idx === liveState.activeAthleteIndex && <span>▶</span>}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {!activeCategory && liveState.activeCategoryId && (
+        <p style={{ color: '#b91c1c' }}>Selected category not found. It may have been deleted.</p>
+      )}
+    </main>
+  );
+}

--- a/app/api/admin/create-event/route.ts
+++ b/app/api/admin/create-event/route.ts
@@ -70,6 +70,11 @@ export async function POST(request: NextRequest) {
         J3: generateKey(),
       },
       categories: [],
+      liveState: {
+        activeCategoryId: null,
+        activeRun: 1,
+        activeAthleteIndex: 0,
+      },
     };
 
     saveEvent(event);

--- a/app/api/admin/live/route.ts
+++ b/app/api/admin/live/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { loadEvent, updateEvent } from '@/lib/store';
+import { validateAdminKey } from '@/lib/auth';
+import type { LiveState } from '@/lib/types';
+
+/**
+ * GET /api/admin/live
+ * Returns the current live state + categories list (for selectors).
+ */
+export async function GET(request: NextRequest) {
+  const key = request.nextUrl.searchParams.get('key');
+  if (!validateAdminKey(key)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const event = loadEvent();
+  if (!event) {
+    return NextResponse.json({ error: 'No event found' }, { status: 404 });
+  }
+
+  const liveState: LiveState = event.liveState ?? {
+    activeCategoryId: null,
+    activeRun: 1,
+    activeAthleteIndex: 0,
+  };
+
+  // Derive the active category & its athletes for the UI
+  const activeCategory = liveState.activeCategoryId
+    ? event.categories.find((c) => c.id === liveState.activeCategoryId) ?? null
+    : null;
+
+  return NextResponse.json({
+    liveState,
+    categories: event.categories.map((c) => ({
+      id: c.id,
+      name: c.name,
+      athleteCount: c.athletes.length,
+    })),
+    activeCategory: activeCategory
+      ? {
+          id: activeCategory.id,
+          name: activeCategory.name,
+          athletes: activeCategory.athletes,
+        }
+      : null,
+  });
+}
+
+/**
+ * PUT /api/admin/live
+ * Updates the live state.
+ * Body: Partial<LiveState> — only provided fields are updated.
+ */
+export async function PUT(request: NextRequest) {
+  const key = request.nextUrl.searchParams.get('key');
+  if (!validateAdminKey(key)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const event = loadEvent();
+  if (!event) {
+    return NextResponse.json({ error: 'No event found' }, { status: 404 });
+  }
+
+  const body = await request.json();
+
+  const currentLive: LiveState = event.liveState ?? {
+    activeCategoryId: null,
+    activeRun: 1,
+    activeAthleteIndex: 0,
+  };
+
+  // Apply partial updates
+  const updated: LiveState = { ...currentLive };
+
+  if ('activeCategoryId' in body) {
+    if (body.activeCategoryId !== null && typeof body.activeCategoryId !== 'string') {
+      return NextResponse.json(
+        { error: 'activeCategoryId must be a string or null' },
+        { status: 400 }
+      );
+    }
+    updated.activeCategoryId = body.activeCategoryId;
+
+    // Reset athlete index when category changes
+    if (body.activeCategoryId !== currentLive.activeCategoryId) {
+      updated.activeAthleteIndex = 0;
+    }
+  }
+
+  if ('activeRun' in body) {
+    if (body.activeRun !== 1 && body.activeRun !== 2) {
+      return NextResponse.json(
+        { error: 'activeRun must be 1 or 2' },
+        { status: 400 }
+      );
+    }
+    updated.activeRun = body.activeRun;
+  }
+
+  if ('activeAthleteIndex' in body) {
+    if (typeof body.activeAthleteIndex !== 'number' || body.activeAthleteIndex < 0) {
+      return NextResponse.json(
+        { error: 'activeAthleteIndex must be a non-negative number' },
+        { status: 400 }
+      );
+    }
+    updated.activeAthleteIndex = body.activeAthleteIndex;
+  }
+
+  // Clamp activeAthleteIndex to valid range
+  if (updated.activeCategoryId) {
+    const cat = event.categories.find((c) => c.id === updated.activeCategoryId);
+    const count = cat?.athletes.length ?? 0;
+    if (count === 0) {
+      updated.activeAthleteIndex = 0;
+    } else if (updated.activeAthleteIndex >= count) {
+      updated.activeAthleteIndex = count - 1;
+    }
+  }
+
+  updateEvent({ liveState: updated });
+
+  return NextResponse.json({ liveState: updated });
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -54,6 +54,15 @@ export function isCategory(value: unknown): value is Category {
 }
 
 /**
+ * Live event state — tracks the active category, run, and athlete.
+ */
+export interface LiveState {
+  activeCategoryId: string | null;
+  activeRun: 1 | 2;
+  activeAthleteIndex: number; // index into sorted athletes array, 0 when empty
+}
+
+/**
  * EventData represents a persistent event record.
  *
  * @property id         - Unique identifier (non-empty string)
@@ -62,6 +71,7 @@ export function isCategory(value: unknown): value is Category {
  * @property adminKey   - Cryptographic secret for admin access
  * @property judgeKeys  - Map of judge role → secret key
  * @property categories - Scoring categories for the event
+ * @property liveState  - Current live competition state
  */
 export interface EventData {
   id: string;
@@ -70,6 +80,7 @@ export interface EventData {
   adminKey: string;
   judgeKeys: Record<JudgeRole, string>;
   categories: Category[];
+  liveState: LiveState;
 }
 
 /**
@@ -98,6 +109,15 @@ export function isEventData(value: unknown): value is EventData {
   if ('categories' in obj) {
     if (!Array.isArray(obj.categories)) return false;
     if (!obj.categories.every(isCategory)) return false;
+  }
+
+  // LiveState: optional for backward compat
+  if ('liveState' in obj) {
+    if (!obj.liveState || typeof obj.liveState !== 'object') return false;
+    const ls = obj.liveState as Record<string, unknown>;
+    if (ls.activeCategoryId !== null && typeof ls.activeCategoryId !== 'string') return false;
+    if (ls.activeRun !== 1 && ls.activeRun !== 2) return false;
+    if (typeof ls.activeAthleteIndex !== 'number') return false;
   }
 
   return true;


### PR DESCRIPTION
## Changes
- **LiveState type** added to `lib/types.ts` (activeCategoryId, activeRun, activeAthleteIndex)
- **isEventData** type guard updated for backward compat
- **create-event** seeds default liveState on new events
- **/api/admin/live** GET + PUT route (partial updates, auto-clamp, category-change reset)
- **/admin/live** page: category selector, run toggle (1/2), rider list with highlight, prev/next buttons

## Files changed
- lib/types.ts
- app/api/admin/create-event/route.ts
- app/api/admin/live/route.ts (new)
- app/admin/live/page.tsx (new)