### PR TITLE
feat(US-A07): Judge scoring page

### DIFF
--- a/app/api/admin/create-event/route.ts
+++ b/app/api/admin/create-event/route.ts
@@ -75,6 +75,7 @@ export async function POST(request: NextRequest) {
         activeRun: 1,
         activeAthleteIndex: 0,
       },
+      scores: [],
     };
 
     saveEvent(event);

--- a/app/api/judge/score/route.ts
+++ b/app/api/judge/score/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { loadEvent, updateEvent } from '@/lib/store';
+import { validateJudgeKey } from '@/lib/auth';
+import type { Score } from '@/lib/types';
+
+/**
+ * POST /api/judge/score?key=...
+ * Submit a score for the currently active athlete/category/run.
+ * Body: { value: number }   (1–100)
+ */
+export async function POST(request: NextRequest) {
+  const key = request.nextUrl.searchParams.get('key');
+  const role = validateJudgeKey(key);
+  if (!role) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const event = loadEvent();
+  if (!event) {
+    return NextResponse.json({ error: 'No event found' }, { status: 404 });
+  }
+
+  const body = await request.json();
+  const value = body?.value;
+
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1 || value > 100) {
+    return NextResponse.json(
+      { error: 'value must be an integer 1–100' },
+      { status: 400 }
+    );
+  }
+
+  const live = event.liveState ?? {
+    activeCategoryId: null,
+    activeRun: 1 as const,
+    activeAthleteIndex: 0,
+  };
+
+  if (!live.activeCategoryId) {
+    return NextResponse.json(
+      { error: 'No active category' },
+      { status: 409 }
+    );
+  }
+
+  const category = event.categories.find((c) => c.id === live.activeCategoryId);
+  if (!category) {
+    return NextResponse.json(
+      { error: 'Active category not found' },
+      { status: 409 }
+    );
+  }
+
+  const athletes = category.athletes;
+  if (athletes.length === 0) {
+    return NextResponse.json(
+      { error: 'No athletes in active category' },
+      { status: 409 }
+    );
+  }
+
+  const idx = Math.min(Math.max(live.activeAthleteIndex, 0), athletes.length - 1);
+  const athlete = athletes[idx];
+
+  const score: Score = {
+    judgeRole: role,
+    categoryId: live.activeCategoryId,
+    athleteBib: athlete.bib,
+    run: live.activeRun,
+    value,
+  };
+
+  // Upsert: replace any existing score for this judge/category/athlete/run
+  const scores = (event.scores ?? []).filter(
+    (s) =>
+      !(
+        s.judgeRole === score.judgeRole &&
+        s.categoryId === score.categoryId &&
+        s.athleteBib === score.athleteBib &&
+        s.run === score.run
+      )
+  );
+  scores.push(score);
+
+  updateEvent({ scores });
+
+  return NextResponse.json({ score }, { status: 201 });
+}
+
+/**
+ * GET /api/judge/score?key=...
+ * Returns the current judge's score for the active athlete/category/run
+ * (if any), so the UI can show it.
+ */
+export async function GET(request: NextRequest) {
+  const key = request.nextUrl.searchParams.get('key');
+  const role = validateJudgeKey(key);
+  if (!role) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const event = loadEvent();
+  if (!event) {
+    return NextResponse.json({ score: null }, { headers: { 'Cache-Control': 'no-store' } });
+  }
+
+  const live = event.liveState ?? {
+    activeCategoryId: null,
+    activeRun: 1 as const,
+    activeAthleteIndex: 0,
+  };
+
+  if (!live.activeCategoryId) {
+    return NextResponse.json({ score: null }, { headers: { 'Cache-Control': 'no-store' } });
+  }
+
+  const category = event.categories.find((c) => c.id === live.activeCategoryId);
+  if (!category || category.athletes.length === 0) {
+    return NextResponse.json({ score: null }, { headers: { 'Cache-Control': 'no-store' } });
+  }
+
+  const idx = Math.min(Math.max(live.activeAthleteIndex, 0), category.athletes.length - 1);
+  const athlete = category.athletes[idx];
+
+  const existing = (event.scores ?? []).find(
+    (s) =>
+      s.judgeRole === role &&
+      s.categoryId === live.activeCategoryId &&
+      s.athleteBib === athlete.bib &&
+      s.run === live.activeRun
+  );
+
+  return NextResponse.json(
+    { score: existing ?? null },
+    { headers: { 'Cache-Control': 'no-store' } }
+  );
+}

--- a/app/judge/[role]/page.tsx
+++ b/app/judge/[role]/page.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import { useEffect, useState, useCallback, useRef, Suspense } from 'react';
+import { useSearchParams, useParams } from 'next/navigation';
+
+interface LiveState {
+  event: string | null;
+  category: { id: string; name: string } | null;
+  run: 1 | 2;
+  athlete: { bib: number; name: string } | null;
+  athleteIndex: number;
+  athleteCount: number;
+}
+
+interface ExistingScore {
+  value: number;
+}
+
+const VALID_ROLES = ['J1', 'J2', 'J3'];
+
+export default function JudgeRolePage() {
+  return (
+    <Suspense fallback={<main style={{ padding: '2rem', fontFamily: 'system-ui, sans-serif' }}><p>Loading…</p></main>}>
+      <JudgeRoleInner />
+    </Suspense>
+  );
+}
+
+function JudgeRoleInner() {
+  const params = useParams();
+  const searchParams = useSearchParams();
+  const role = (params.role as string)?.toUpperCase();
+  const key = searchParams.get('key') ?? '';
+
+  const [state, setState] = useState<LiveState>({
+    event: null,
+    category: null,
+    run: 1,
+    athlete: null,
+    athleteIndex: 0,
+    athleteCount: 0,
+  });
+  const [scoreInput, setScoreInput] = useState('');
+  const [existingScore, setExistingScore] = useState<ExistingScore | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [successMsg, setSuccessMsg] = useState('');
+  const [error, setError] = useState('');
+
+  // Track the previous athlete/run/category to detect changes
+  const prevRef = useRef<string>('');
+
+  const isValidRole = VALID_ROLES.includes(role);
+  const hasRider = !!state.athlete;
+  const canScore = isValidRole && hasRider;
+
+  // Poll /api/state every 1s
+  const fetchState = useCallback(async () => {
+    try {
+      const res = await fetch('/api/state');
+      if (!res.ok) return;
+      const data: LiveState = await res.json();
+      setState(data);
+    } catch {
+      // silent — polling will retry
+    }
+  }, []);
+
+  // Fetch existing score for this judge/athlete/run
+  const fetchScore = useCallback(async () => {
+    if (!key) return;
+    try {
+      const res = await fetch(`/api/judge/score?key=${encodeURIComponent(key)}`);
+      if (!res.ok) return;
+      const data = await res.json();
+      setExistingScore(data.score);
+    } catch {
+      // silent
+    }
+  }, [key]);
+
+  useEffect(() => {
+    fetchState();
+    fetchScore();
+    const interval = setInterval(() => {
+      fetchState();
+      // Only poll score when there's an active rider
+      if (prevRef.current && prevRef.current !== '||1') {
+        fetchScore();
+      }
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [fetchState, fetchScore]);
+
+  // Reset input and success msg when athlete/run/category changes
+  useEffect(() => {
+    const sig = `${state.category?.id ?? ''}|${state.athlete?.bib ?? ''}|${state.run}`;
+    if (prevRef.current && prevRef.current !== sig) {
+      setScoreInput('');
+      setSuccessMsg('');
+      setError('');
+    }
+    prevRef.current = sig;
+  }, [state.category?.id, state.athlete?.bib, state.run]);
+
+  const handleSubmit = async () => {
+    const val = parseInt(scoreInput, 10);
+    if (isNaN(val) || val < 1 || val > 100) {
+      setError('Score must be 1–100');
+      return;
+    }
+    setSubmitting(true);
+    setError('');
+    setSuccessMsg('');
+    try {
+      const res = await fetch(`/api/judge/score?key=${encodeURIComponent(key)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value: val }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error ?? 'Failed to submit');
+        return;
+      }
+      setSuccessMsg(`Score ${val} submitted`);
+      setExistingScore({ value: val });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Network error');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!isValidRole) {
+    return (
+      <main style={{ padding: '2rem', fontFamily: 'system-ui, sans-serif' }}>
+        <h1 style={{ color: '#b91c1c' }}>Invalid Judge Role</h1>
+        <p>Valid roles: J1, J2, J3</p>
+      </main>
+    );
+  }
+
+  return (
+    <main style={{ padding: '2rem', fontFamily: 'system-ui, sans-serif', maxWidth: 500, margin: '0 auto' }}>
+      <h1 style={{ marginBottom: '0.25rem' }}>Judge {role}</h1>
+      <p style={{ color: '#6b7280', marginTop: 0, marginBottom: '1.5rem' }}>
+        {state.event ?? 'No event'}
+      </p>
+
+      {/* Current state display */}
+      <section
+        style={{
+          padding: '1rem',
+          background: canScore ? '#eff6ff' : '#f3f4f6',
+          border: `2px solid ${canScore ? '#2563eb' : '#d1d5db'}`,
+          borderRadius: 8,
+          marginBottom: '1.5rem',
+          textAlign: 'center',
+        }}
+      >
+        {state.category ? (
+          <>
+            <div style={{ fontSize: '0.875rem', color: '#6b7280', marginBottom: '0.25rem' }}>
+              {state.category.name} — Run {state.run}
+            </div>
+            {state.athlete ? (
+              <div style={{ fontSize: '1.5rem', fontWeight: 700 }}>
+                #{state.athlete.bib} {state.athlete.name}
+              </div>
+            ) : (
+              <div style={{ fontSize: '1.25rem', color: '#9ca3af' }}>No rider</div>
+            )}
+            <div style={{ fontSize: '0.75rem', color: '#9ca3af', marginTop: '0.25rem' }}>
+              Rider {state.athleteIndex + 1} / {state.athleteCount}
+            </div>
+          </>
+        ) : (
+          <div style={{ fontSize: '1.25rem', color: '#9ca3af' }}>Waiting for category…</div>
+        )}
+      </section>
+
+      {/* Existing score indicator */}
+      {existingScore && (
+        <div
+          style={{
+            padding: '0.5rem 0.75rem',
+            background: '#f0fdf4',
+            border: '1px solid #86efac',
+            borderRadius: 6,
+            marginBottom: '1rem',
+            fontSize: '0.875rem',
+            color: '#166534',
+          }}
+        >
+          Your current score: <strong>{existingScore.value}</strong>
+        </div>
+      )}
+
+      {/* Score input */}
+      <section style={{ marginBottom: '1rem' }}>
+        <label style={{ fontWeight: 600, display: 'block', marginBottom: '0.5rem' }}>
+          Score (1–100)
+        </label>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <input
+            type="number"
+            min={1}
+            max={100}
+            value={scoreInput}
+            onChange={(e) => setScoreInput(e.target.value)}
+            disabled={!canScore || submitting}
+            placeholder={canScore ? 'Enter score' : 'Waiting…'}
+            onKeyDown={(e) => { if (e.key === 'Enter' && canScore && !submitting) handleSubmit(); }}
+            style={{
+              flex: 1,
+              padding: '0.75rem',
+              fontSize: '1.25rem',
+              border: '1px solid #ccc',
+              borderRadius: 4,
+              textAlign: 'center',
+              opacity: canScore ? 1 : 0.4,
+            }}
+          />
+          <button
+            onClick={handleSubmit}
+            disabled={!canScore || submitting || !scoreInput}
+            style={{
+              padding: '0.75rem 1.5rem',
+              fontSize: '1rem',
+              fontWeight: 700,
+              border: 'none',
+              borderRadius: 4,
+              backgroundColor: canScore && scoreInput ? '#2563eb' : '#d1d5db',
+              color: canScore && scoreInput ? '#fff' : '#9ca3af',
+              cursor: canScore && scoreInput ? 'pointer' : 'not-allowed',
+            }}
+          >
+            {submitting ? '…' : 'Submit'}
+          </button>
+        </div>
+      </section>
+
+      {/* Feedback */}
+      {error && (
+        <div style={{ color: '#b91c1c', background: '#fef2f2', padding: '0.5rem 0.75rem', borderRadius: 6, marginBottom: '0.5rem' }}>
+          {error}
+        </div>
+      )}
+      {successMsg && (
+        <div style={{ color: '#166534', background: '#f0fdf4', padding: '0.5rem 0.75rem', borderRadius: 6 }}>
+          {successMsg}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -54,6 +54,17 @@ export function isCategory(value: unknown): value is Category {
 }
 
 /**
+ * A score submitted by a judge for a specific athlete/category/run.
+ */
+export interface Score {
+  judgeRole: JudgeRole;
+  categoryId: string;
+  athleteBib: number;
+  run: 1 | 2;
+  value: number; // 1-100
+}
+
+/**
  * Live event state — tracks the active category, run, and athlete.
  */
 export interface LiveState {
@@ -72,6 +83,7 @@ export interface LiveState {
  * @property judgeKeys  - Map of judge role → secret key
  * @property categories - Scoring categories for the event
  * @property liveState  - Current live competition state
+ * @property scores     - All submitted judge scores
  */
 export interface EventData {
   id: string;
@@ -81,6 +93,7 @@ export interface EventData {
   judgeKeys: Record<JudgeRole, string>;
   categories: Category[];
   liveState: LiveState;
+  scores: Score[];
 }
 
 /**
@@ -109,6 +122,11 @@ export function isEventData(value: unknown): value is EventData {
   if ('categories' in obj) {
     if (!Array.isArray(obj.categories)) return false;
     if (!obj.categories.every(isCategory)) return false;
+  }
+
+  // Scores: optional for backward compat
+  if ('scores' in obj) {
+    if (!Array.isArray(obj.scores)) return false;
   }
 
   // LiveState: optional for backward compat


### PR DESCRIPTION
## Changes
- **Score type** added to `lib/types.ts`, `scores[]` field on `EventData`
- **`/api/judge/score`** POST (submit, upsert) + GET (read current score) — judge key validated
- **`/judge/[role]`** page: polls `/api/state` every 1s, shows current rider/run/category, score input 1–100, auto-resets on rider change
- **create-event** seeds `scores: []`
- Input disabled when no rider or no category active

## Files changed
- lib/types.ts (Score interface, scores field)
- app/api/admin/create-event/route.ts (seed scores)
- app/api/judge/score/route.ts (new)
- app/judge/[role]/page.tsx (new)