### PR TITLE
US-A08: /api/score endpoint

### DIFF
--- a/app/api/admin/create-event/route.ts
+++ b/app/api/admin/create-event/route.ts
@@ -75,6 +75,7 @@ export async function POST(request: NextRequest) {
         activeRun: 1,
         activeAthleteIndex: 0,
       },
+      scores: [],
     };
 
     saveEvent(event);

--- a/app/api/score/route.ts
+++ b/app/api/score/route.ts
@@ -1,0 +1,174 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { loadEvent, updateEvent } from '@/lib/store';
+import { validateJudgeKey } from '@/lib/auth';
+import type { Score } from '@/lib/types';
+
+/**
+ * POST /api/score?key=<judgeKey>
+ *
+ * Submit or update a score for the currently active athlete / category / run.
+ * Body: { "value": <number 1–100> }
+ *
+ * Auth:   judge key (query param) → role is derived automatically.
+ * Lock:   rejects with 409 when no category / athlete is active.
+ * Upsert: replaces any previous score for the same judge + category +
+ *         athlete + run combination.
+ * Persist: atomic temp-file-then-rename via updateEvent().
+ */
+export async function POST(request: NextRequest) {
+  /* ── 1. Validate role & key ─────────────────────────────────── */
+  const key = request.nextUrl.searchParams.get('key');
+  const role = validateJudgeKey(key);
+  if (!role) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  /* ── 2. Load event ──────────────────────────────────────────── */
+  const event = loadEvent();
+  if (!event) {
+    return NextResponse.json({ error: 'No event found' }, { status: 404 });
+  }
+
+  /* ── 3. Validate score range ────────────────────────────────── */
+  const body = await request.json();
+  const value = body?.value;
+
+  if (
+    typeof value !== 'number' ||
+    !Number.isInteger(value) ||
+    value < 1 ||
+    value > 100
+  ) {
+    return NextResponse.json(
+      { error: 'value must be an integer 1–100' },
+      { status: 400 },
+    );
+  }
+
+  /* ── 4. Reject if run is locked (no active category / athlete) */
+  const live = event.liveState ?? {
+    activeCategoryId: null,
+    activeRun: 1 as const,
+    activeAthleteIndex: 0,
+  };
+
+  if (!live.activeCategoryId) {
+    return NextResponse.json(
+      { error: 'No active category' },
+      { status: 409 },
+    );
+  }
+
+  const category = event.categories.find(
+    (c) => c.id === live.activeCategoryId,
+  );
+  if (!category) {
+    return NextResponse.json(
+      { error: 'Active category not found' },
+      { status: 409 },
+    );
+  }
+
+  const athletes = category.athletes;
+  if (athletes.length === 0) {
+    return NextResponse.json(
+      { error: 'No athletes in active category' },
+      { status: 409 },
+    );
+  }
+
+  const idx = Math.min(
+    Math.max(live.activeAthleteIndex, 0),
+    athletes.length - 1,
+  );
+  const athlete = athletes[idx];
+
+  /* ── 5. Upsert score for active attempt ─────────────────────── */
+  const score: Score = {
+    judgeRole: role,
+    categoryId: live.activeCategoryId,
+    athleteBib: athlete.bib,
+    run: live.activeRun,
+    value,
+  };
+
+  const scores = (event.scores ?? []).filter(
+    (s) =>
+      !(
+        s.judgeRole === score.judgeRole &&
+        s.categoryId === score.categoryId &&
+        s.athleteBib === score.athleteBib &&
+        s.run === score.run
+      ),
+  );
+  scores.push(score);
+
+  /* ── 6. Persist atomically ──────────────────────────────────── */
+  updateEvent({ scores });
+
+  return NextResponse.json({ score }, { status: 201 });
+}
+
+/**
+ * GET /api/score?key=<judgeKey>
+ *
+ * Returns the judge's existing score for the active athlete / category / run,
+ * or null if no score has been submitted yet.
+ */
+export async function GET(request: NextRequest) {
+  const key = request.nextUrl.searchParams.get('key');
+  const role = validateJudgeKey(key);
+  if (!role) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const event = loadEvent();
+  if (!event) {
+    return NextResponse.json(
+      { score: null },
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+
+  const live = event.liveState ?? {
+    activeCategoryId: null,
+    activeRun: 1 as const,
+    activeAthleteIndex: 0,
+  };
+
+  if (!live.activeCategoryId) {
+    return NextResponse.json(
+      { score: null },
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+
+  const category = event.categories.find(
+    (c) => c.id === live.activeCategoryId,
+  );
+  if (!category || category.athletes.length === 0) {
+    return NextResponse.json(
+      { score: null },
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+
+  const idx = Math.min(
+    Math.max(live.activeAthleteIndex, 0),
+    category.athletes.length - 1,
+  );
+  const athlete = category.athletes[idx];
+
+  const existing = (event.scores ?? []).find(
+    (s) =>
+      s.judgeRole === role &&
+      s.categoryId === live.activeCategoryId &&
+      s.athleteBib === athlete.bib &&
+      s.run === live.activeRun,
+  );
+
+  return NextResponse.json(
+    { score: existing ?? null },
+    { headers: { 'Cache-Control': 'no-store' } },
+  );
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -54,6 +54,17 @@ export function isCategory(value: unknown): value is Category {
 }
 
 /**
+ * A score submitted by a judge for a specific athlete/category/run.
+ */
+export interface Score {
+  judgeRole: JudgeRole;
+  categoryId: string;
+  athleteBib: number;
+  run: 1 | 2;
+  value: number; // 1-100
+}
+
+/**
  * Live event state — tracks the active category, run, and athlete.
  */
 export interface LiveState {
@@ -72,6 +83,7 @@ export interface LiveState {
  * @property judgeKeys  - Map of judge role → secret key
  * @property categories - Scoring categories for the event
  * @property liveState  - Current live competition state
+ * @property scores     - All submitted judge scores
  */
 export interface EventData {
   id: string;
@@ -81,6 +93,7 @@ export interface EventData {
   judgeKeys: Record<JudgeRole, string>;
   categories: Category[];
   liveState: LiveState;
+  scores: Score[];
 }
 
 /**
@@ -109,6 +122,11 @@ export function isEventData(value: unknown): value is EventData {
   if ('categories' in obj) {
     if (!Array.isArray(obj.categories)) return false;
     if (!obj.categories.every(isCategory)) return false;
+  }
+
+  // Scores: optional for backward compat
+  if ('scores' in obj) {
+    if (!Array.isArray(obj.scores)) return false;
   }
 
   // LiveState: optional for backward compat


### PR DESCRIPTION
## US-A08 — /api/score endpoint

### Changes
- **lib/types.ts** — Added `Score` interface and `scores: Score[]` to `EventData`; updated `isEventData` type guard
- **app/api/admin/create-event/route.ts** — Seed `scores: []` on event creation
- **app/api/score/route.ts** — New endpoint (POST + GET)

### Behaviour
| Check | Detail |
|-------|--------|
| Auth | Judge key via `?key=` → role derived automatically |
| Validation | `value` must be integer 1–100 |
| Lock | 409 when no active category/athlete |
| Upsert | Replaces previous score for same judge+category+athlete+run |
| Persist | Atomic temp-file → rename via `updateEvent()` |
| GET | Returns existing score for current judge/active athlete/run |