### PR TITLE
US-A10: Admin lock/unlock controls per category/run

### DIFF
--- a/app/admin/live/page.tsx
+++ b/app/admin/live/page.tsx
@@ -48,6 +48,7 @@ function LiveControlInner() {
     activeAthleteIndex: 0,
   });
   const [judgeScores, setJudgeScores] = useState<JudgeScores>({ J1: null, J2: null, J3: null });
+  const [isLocked, setIsLocked] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
@@ -60,6 +61,7 @@ function LiveControlInner() {
       setCategories(data.categories);
       setActiveCategory(data.activeCategory);
       setJudgeScores(data.judgeScores ?? { J1: null, J2: null, J3: null });
+      setIsLocked(data.isLocked ?? false);
       setError('');
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Unknown error');
@@ -122,6 +124,10 @@ function LiveControlInner() {
 
   const handleSelectAthlete = (index: number) => {
     updateLive({ activeAthleteIndex: index });
+  };
+
+  const handleToggleLock = () => {
+    updateLive({ lock: !isLocked } as unknown as Partial<LiveState>);
   };
 
   if (loading) {
@@ -255,6 +261,28 @@ function LiveControlInner() {
                 );
               })}
             </div>
+          )}
+
+          {/* Lock / Unlock toggle */}
+          {currentAthlete && (
+            <button
+              onClick={handleToggleLock}
+              style={{
+                width: '100%',
+                padding: '0.6rem 1rem',
+                fontSize: '1rem',
+                fontWeight: 600,
+                border: '2px solid',
+                borderColor: isLocked ? '#dc2626' : '#16a34a',
+                backgroundColor: isLocked ? '#fef2f2' : '#f0fdf4',
+                color: isLocked ? '#dc2626' : '#16a34a',
+                borderRadius: 6,
+                cursor: 'pointer',
+                marginBottom: '1rem',
+              }}
+            >
+              {isLocked ? '🔒 Locked — Click to Unlock' : '🔓 Unlocked — Click to Lock'}
+            </button>
           )}
 
           {/* Prev / Next */}

--- a/app/api/admin/create-event/route.ts
+++ b/app/api/admin/create-event/route.ts
@@ -76,6 +76,7 @@ export async function POST(request: NextRequest) {
         activeAthleteIndex: 0,
       },
       scores: [],
+      lockedRuns: [],
     };
 
     saveEvent(event);

--- a/app/api/score/route.ts
+++ b/app/api/score/route.ts
@@ -77,6 +77,15 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  /* ── 4b. Reject if category/run is locked ─────────────────── */
+  const lockKey = `${live.activeCategoryId}:${live.activeRun}`;
+  if ((event.lockedRuns ?? []).includes(lockKey)) {
+    return NextResponse.json(
+      { error: 'This run is locked' },
+      { status: 423 },
+    );
+  }
+
   const idx = Math.min(
     Math.max(live.activeAthleteIndex, 0),
     athletes.length - 1,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -84,6 +84,7 @@ export interface LiveState {
  * @property categories - Scoring categories for the event
  * @property liveState  - Current live competition state
  * @property scores     - All submitted judge scores
+ * @property lockedRuns - Lock keys ("categoryId:run") preventing further scoring
  */
 export interface EventData {
   id: string;
@@ -94,6 +95,7 @@ export interface EventData {
   categories: Category[];
   liveState: LiveState;
   scores: Score[];
+  lockedRuns: string[];
 }
 
 /**
@@ -127,6 +129,11 @@ export function isEventData(value: unknown): value is EventData {
   // Scores: optional for backward compat
   if ('scores' in obj) {
     if (!Array.isArray(obj.scores)) return false;
+  }
+
+  // LockedRuns: optional for backward compat
+  if ('lockedRuns' in obj) {
+    if (!Array.isArray(obj.lockedRuns)) return false;
   }
 
   // LiveState: optional for backward compat


### PR DESCRIPTION
US-A10: Admin lock/unlock controls per category/run. Adds lockedRuns to EventData, lock toggle in admin live page, and 423 enforcement in /api/score.