### PR TITLE
US-A16: Admin JSON export/import with structure validation

### DIFF
--- a/app/api/export/json/route.ts
+++ b/app/api/export/json/route.ts
@@ -77,11 +77,21 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  /* ── Merge: keep current secret keys ────────────────────────────────── */
-  const merged = {
-    ...(body as Record<string, unknown>),
+  /* ── Merge: keep current secret keys, default optional fields ─────── */
+  const raw = body as Record<string, unknown>;
+  const merged: Record<string, unknown> = {
+    ...raw,
     adminKey: currentEvent.adminKey,
     judgeKeys: currentEvent.judgeKeys,
+    categories: raw.categories ?? [],
+    scores: raw.scores ?? [],
+    lockedRuns: raw.lockedRuns ?? [],
+    liveState: raw.liveState ?? {
+      activeCategoryId: null,
+      activeRun: 1,
+      activeAthleteIndex: 0,
+      activeAttemptNumber: 1,
+    },
   };
 
   /* ── Validate full structure ────────────────────────────────────────── */


### PR DESCRIPTION
## US-A16: Admin JSON export/import with structure validation

### What
- **GET `/api/export/json?key=…`** — download full event as JSON (secrets stripped)
- **POST `/api/export/json?key=…`** — import JSON backup, validate, atomically replace `event.json`

### Key design decisions
- **Secrets preserved**: admin & judge keys are stripped on export and re-injected from current event on import — existing links keep working
- **Deep validation**: `isEventData()` gate + score field checks (judgeRole, value, run, attempt) + category ID uniqueness + bib uniqueness + score→category/athlete reference integrity
- **Backward compat**: missing `scores`, `lockedRuns`, `liveState`, `categories` default to empty/initial values
- **Atomic save**: delegates to `saveEvent()` (temp-file-then-rename)

### Files changed
| File | Change |
|---|---|
| `app/api/export/json/route.ts` | **Created** — GET (export) + POST (import) |

### Test results
33/33 PASS across 5 scenarios: export backup, import valid, import invalid (8 rejection cases), import old version, refresh after import.
