### PR TITLE
US-B02: Head Judge overall and per-judge leaderboards

### DIFF
--- a/app/api/admin/results/route.ts
+++ b/app/api/admin/results/route.ts
@@ -2,12 +2,18 @@ import { NextRequest, NextResponse } from 'next/server';
 import { loadEvent } from '@/lib/store';
 import { validateAdminKey } from '@/lib/auth';
 import { rankAthletes } from '@/lib/scoring';
+import { JUDGE_ROLES } from '@/lib/types';
+import type { JudgeRole } from '@/lib/types';
 
 /**
- * GET /api/admin/results?key=…&categoryId=…
+ * GET /api/admin/results?key=…&categoryId=…[&judge=J1|J2|J3]
  *
  * Returns categories list and, when categoryId is provided, the ranked
  * leaderboard for all athletes in that category.
+ *
+ * Optional `judge` param filters scores to a single judge, producing a
+ * per-judge leaderboard (US-B02). When omitted the overall leaderboard
+ * (all judges) is returned.
  */
 export async function GET(request: NextRequest) {
   const key = request.nextUrl.searchParams.get('key');
@@ -29,7 +35,7 @@ export async function GET(request: NextRequest) {
   const categoryId = request.nextUrl.searchParams.get('categoryId');
 
   if (!categoryId) {
-    return NextResponse.json({ categories: categorySummaries, leaderboard: null });
+    return NextResponse.json({ categories: categorySummaries, leaderboard: null, judge: null });
   }
 
   const category = event.categories.find((c) => c.id === categoryId);
@@ -37,15 +43,29 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Category not found' }, { status: 404 });
   }
 
-  // Rank athletes within this category using scoring.ts
-  const ranked = rankAthletes(
-    event.scores ?? [],
-    [category],
-    category.athletes,
-  );
+  // Optional per-judge filter (US-B02)
+  const judgeParam = request.nextUrl.searchParams.get('judge');
+  let judgeFilter: JudgeRole | null = null;
+
+  if (judgeParam) {
+    if (!(JUDGE_ROLES as readonly string[]).includes(judgeParam)) {
+      return NextResponse.json({ error: 'Invalid judge role' }, { status: 400 });
+    }
+    judgeFilter = judgeParam as JudgeRole;
+  }
+
+  // Filter scores: all for this category, optionally narrowed to one judge
+  const allScores = event.scores ?? [];
+  const scores = judgeFilter
+    ? allScores.filter((s) => s.categoryId === category.id && s.judgeRole === judgeFilter)
+    : allScores;
+
+  // Rank athletes within this category
+  const ranked = rankAthletes(scores, [category], category.athletes);
 
   return NextResponse.json({
     categories: categorySummaries,
     leaderboard: ranked,
+    judge: judgeFilter,
   });
 }


### PR DESCRIPTION
﻿## US-B02: Head Judge sees overall and per-judge leaderboards

### Changes
- **app/api/admin/results/route.ts**  Added optional `judge` query param (`J1`/`J2`/`J3`). When present, filters scores to that judge before ranking. Invalid values return 400. Response now includes `judge` field.
- **app/admin/results/page.tsx**  Added segmented view switcher (Overall / J1 / J2 / J3), 2s polling for live updates, per-judge empty state text, tie display with "T" suffix on rank.

### Acceptance Criteria
| AC | Status |
|----|--------|
| Head Judge screen shows an overall leaderboard |  Default "Overall" view |
| Head Judge can view a leaderboard for each individual scoring judge |  J1/J2/J3 buttons |
| Leaderboards update live when scores change |  2s polling via setInterval |
| Individual judge leaderboards reflect only that judge's scores |  API filters by judgeRole |
| Head Judge can switch between leaderboard views |  Segmented control, no reload |

### No duplication with US-B01
- US-B01's `/api/score/leaderboard` is judge-key auth + live-state category
- US-B02's `/api/admin/results` is admin-key auth + admin-selected category
- Both reuse `rankAthletes()` from `lib/scoring.ts`
