### PR TITLE
US-REF-00: Codebase Health Baseline

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -32,7 +32,7 @@
 
 | US | Title | Branch | Notes |
 |----|-------|--------|-------|
-| — | — | — | No stories in progress |
+| US-REF-00 | Codebase Health Baseline | feature/US-REF-00 | Consolidation + tests + cleanup |
 
 ## Backlog / Ideas
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -32,10 +32,36 @@
 
 | US | Title | Branch | Notes |
 |----|-------|--------|-------|
-| US-REF-00 | Codebase Health Baseline | feature/US-REF-00 | Consolidation + tests + cleanup |
+| US-REF-00 | Codebase Health Baseline | feature/US-REF-00 | PR pending — review + test passed |
+
+### US-REF-00 Summary
+
+**Consolidated:**
+- Eliminated duplicated interfaces across 4 client pages → shared `lib/client-types.ts`
+- Removed all `as unknown as` type casts (live page lock/rerun calls)
+- Unified `LiveState` default values → `DEFAULT_LIVE_STATE` constant (single source of truth)
+- Shared table styles (`thStyle`/`tdStyle`) extracted; judge page overrides preserved
+- `RouteContext<T>` generic replaces per-route local type aliases
+
+**Patterns standardized:**
+- `withAdminAuth(handler)` wrapper for admin routes (applied to results route; pattern ready for remaining routes)
+- `LiveUpdatePayload` interface for type-safe live update calls
+- `Cache-Control: no-store` on results endpoint
+- "Rider" → "Athlete" naming across UI
+- Provisional badge hidden in per-judge view (was incorrectly shown)
+- Border overlap fix on results view switcher buttons
+
+**Test coverage added:**
+- Vitest 4.0 configured (`npm test` / `npm run test:watch`)
+- 18 scoring tests: `computeRunScore`, `computeFinalScore`, `rankAthletes` (ties, partial, multi-attempt, rounding, multi-category, stable sort)
+- 13 auth+store tests: `generateKey`, `validateAdminKey`, `validateJudgeKey`, `loadEvent`, `saveEvent`, `updateEvent`
+- 26-scenario manual regression script passed (event lifecycle, scoring, leaderboard, per-judge view, best-of-two-runs, re-run attempts, lock enforcement, exports)
+
+**Files changed:** 20 (4 new, 16 modified)
 
 ## Backlog / Ideas
 
+- Apply `withAdminAuth` wrapper to remaining 6 admin routes (categories, live, create-event, CSV export)
 - Public spectator live-score page (auto-updating)
 - QR code generation for judge URLs
 - Multi-event support

--- a/__tests__/auth-store.test.ts
+++ b/__tests__/auth-store.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { generateKey, validateAdminKey, validateJudgeKey } from '../lib/auth';
+import { loadEvent, saveEvent, updateEvent } from '../lib/store';
+import type { EventData } from '../lib/types';
+import { DEFAULT_LIVE_STATE } from '../lib/types';
+
+// ─── Fixture ─────────────────────────────────────────────────────────────────
+
+const DATA_DIR = path.join(process.cwd(), 'data');
+const EVENT_FILE = path.join(DATA_DIR, 'event.json');
+
+function makeEvent(overrides: Partial<EventData> = {}): EventData {
+  return {
+    id: 'test-id',
+    name: 'Test Event',
+    createdAt: new Date().toISOString(),
+    adminKey: 'admin-key-abc',
+    judgeKeys: { J1: 'j1-key', J2: 'j2-key', J3: 'j3-key' },
+    categories: [],
+    liveState: { ...DEFAULT_LIVE_STATE },
+    scores: [],
+    lockedRuns: [],
+    ...overrides,
+  };
+}
+
+/** Back up and restore event.json around tests to avoid side effects. */
+let backup: string | null = null;
+
+beforeEach(() => {
+  if (fs.existsSync(EVENT_FILE)) {
+    backup = fs.readFileSync(EVENT_FILE, 'utf-8');
+  } else {
+    backup = null;
+  }
+});
+
+afterEach(() => {
+  if (backup !== null) {
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+    fs.writeFileSync(EVENT_FILE, backup, 'utf-8');
+  } else if (fs.existsSync(EVENT_FILE)) {
+    fs.unlinkSync(EVENT_FILE);
+  }
+});
+
+// ─── generateKey ─────────────────────────────────────────────────────────────
+
+describe('generateKey', () => {
+  it('T-A01: returns base64url string from 32 random bytes', () => {
+    const key = generateKey();
+    expect(typeof key).toBe('string');
+    // 32 bytes → 43 base64url chars (no padding)
+    expect(key.length).toBe(43);
+    // No padding characters
+    expect(key).not.toContain('=');
+    // Valid base64url character set
+    expect(key).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it('generates unique keys', () => {
+    const keys = new Set(Array.from({ length: 10 }, () => generateKey()));
+    expect(keys.size).toBe(10);
+  });
+});
+
+// ─── validateAdminKey ────────────────────────────────────────────────────────
+
+describe('validateAdminKey', () => {
+  it('T-A02: matches loaded event admin key', () => {
+    const event = makeEvent({ adminKey: 'my-secret-admin-key-1234567890aaa' });
+    saveEvent(event);
+    expect(validateAdminKey('my-secret-admin-key-1234567890aaa')).toBe(true);
+  });
+
+  it('T-A03: rejects wrong key', () => {
+    const event = makeEvent({ adminKey: 'correct-key-abcdefghij1234567890' });
+    saveEvent(event);
+    expect(validateAdminKey('wrong-key-abcdefghijkl1234567890x')).toBe(false);
+  });
+
+  it('T-A06: null key → false (no crash)', () => {
+    saveEvent(makeEvent());
+    expect(validateAdminKey(null)).toBe(false);
+  });
+});
+
+// ─── validateJudgeKey ────────────────────────────────────────────────────────
+
+describe('validateJudgeKey', () => {
+  it('T-A04: maps to correct role', () => {
+    const event = makeEvent({
+      judgeKeys: { J1: 'key-j1-aaaa', J2: 'key-j2-bbbb', J3: 'key-j3-cccc' },
+    });
+    saveEvent(event);
+    expect(validateJudgeKey('key-j1-aaaa')).toBe('J1');
+    expect(validateJudgeKey('key-j2-bbbb')).toBe('J2');
+    expect(validateJudgeKey('key-j3-cccc')).toBe('J3');
+  });
+
+  it('T-A05: rejects unknown key', () => {
+    saveEvent(makeEvent());
+    expect(validateJudgeKey('unknown-key')).toBeNull();
+  });
+
+  it('null key → null', () => {
+    saveEvent(makeEvent());
+    expect(validateJudgeKey(null)).toBeNull();
+  });
+});
+
+// ─── store: loadEvent / saveEvent / updateEvent ──────────────────────────────
+
+describe('store', () => {
+  it('T-ST01: saveEvent + loadEvent round-trip', () => {
+    const event = makeEvent({ name: 'Round Trip Event' });
+    saveEvent(event);
+    const loaded = loadEvent();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.name).toBe('Round Trip Event');
+    expect(loaded!.id).toBe(event.id);
+  });
+
+  it('T-ST02: loadEvent when no file → null', () => {
+    if (fs.existsSync(EVENT_FILE)) {
+      fs.unlinkSync(EVENT_FILE);
+    }
+    const loaded = loadEvent();
+    expect(loaded).toBeNull();
+  });
+
+  it('T-ST03: updateEvent merges partial data', () => {
+    saveEvent(makeEvent({ name: 'Original' }));
+    const updated = updateEvent({ name: 'Updated' });
+    expect(updated.name).toBe('Updated');
+    expect(updated.id).toBe('test-id'); // unchanged
+    // Verify persisted
+    const loaded = loadEvent();
+    expect(loaded!.name).toBe('Updated');
+  });
+
+  it('T-ST04: saveEvent rejects malformed data', () => {
+    const bad = { id: '', name: '', createdAt: '' } as unknown as EventData;
+    expect(() => saveEvent(bad)).toThrow();
+  });
+
+  it('updateEvent throws when no event exists', () => {
+    if (fs.existsSync(EVENT_FILE)) {
+      fs.unlinkSync(EVENT_FILE);
+    }
+    expect(() => updateEvent({ name: 'boom' })).toThrow('No event exists');
+  });
+});

--- a/__tests__/scoring.test.ts
+++ b/__tests__/scoring.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeRunScore,
+  computeFinalScore,
+  rankAthletes,
+} from '../lib/scoring';
+import type { Score, Category, Athlete } from '../lib/types';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeScore(
+  overrides: Partial<Score> & { judgeRole: Score['judgeRole']; value: number },
+): Score {
+  return {
+    categoryId: 'cat1',
+    athleteBib: 1,
+    run: 1,
+    attempt: 1,
+    ...overrides,
+  };
+}
+
+const cat1: Category = { id: 'cat1', name: 'Freestyle', athletes: [] };
+
+// ─── computeRunScore ─────────────────────────────────────────────────────────
+
+describe('computeRunScore', () => {
+  it('T-S01: single judge, single attempt → average = value', () => {
+    const scores: Score[] = [
+      makeScore({ judgeRole: 'J1', value: 80 }),
+    ];
+    const result = computeRunScore(scores, 'cat1', 1, 1);
+    expect(result).not.toBeNull();
+    expect(result!.complete).toBe(false);
+    expect(result!.average).toBe(80);
+    expect(result!.attempt).toBe(1);
+    expect(result!.scores).toEqual({ J1: 80, J2: null, J3: null });
+  });
+
+  it('T-S02: 3 judges, all scored → correct average, complete: true', () => {
+    const scores: Score[] = [
+      makeScore({ judgeRole: 'J1', value: 80 }),
+      makeScore({ judgeRole: 'J2', value: 90 }),
+      makeScore({ judgeRole: 'J3', value: 70 }),
+    ];
+    const result = computeRunScore(scores, 'cat1', 1, 1);
+    expect(result).not.toBeNull();
+    expect(result!.complete).toBe(true);
+    expect(result!.average).toBe(80); // (80+90+70)/3 = 80
+    expect(result!.attempt).toBe(1);
+  });
+
+  it('T-S03: 2 of 3 judges → complete: false, average of 2', () => {
+    const scores: Score[] = [
+      makeScore({ judgeRole: 'J1', value: 60 }),
+      makeScore({ judgeRole: 'J3', value: 90 }),
+    ];
+    const result = computeRunScore(scores, 'cat1', 1, 1);
+    expect(result).not.toBeNull();
+    expect(result!.complete).toBe(false);
+    expect(result!.average).toBe(75); // (60+90)/2
+  });
+
+  it('T-S04: 0 judges → returns null', () => {
+    const result = computeRunScore([], 'cat1', 1, 1);
+    expect(result).toBeNull();
+  });
+
+  it('T-S05: multiple attempts → picks best (highest average)', () => {
+    const scores: Score[] = [
+      // Attempt 1: all judges, average = 50
+      makeScore({ judgeRole: 'J1', value: 40, attempt: 1 }),
+      makeScore({ judgeRole: 'J2', value: 50, attempt: 1 }),
+      makeScore({ judgeRole: 'J3', value: 60, attempt: 1 }),
+      // Attempt 2: all judges, average = 80
+      makeScore({ judgeRole: 'J1', value: 70, attempt: 2 }),
+      makeScore({ judgeRole: 'J2', value: 80, attempt: 2 }),
+      makeScore({ judgeRole: 'J3', value: 90, attempt: 2 }),
+    ];
+    const result = computeRunScore(scores, 'cat1', 1, 1);
+    expect(result).not.toBeNull();
+    expect(result!.attempt).toBe(2);
+    expect(result!.average).toBe(80);
+    expect(result!.complete).toBe(true);
+  });
+
+  it('T-S05b: prefers complete attempt over higher-scoring incomplete', () => {
+    const scores: Score[] = [
+      // Attempt 1: complete, average = 60
+      makeScore({ judgeRole: 'J1', value: 50, attempt: 1 }),
+      makeScore({ judgeRole: 'J2', value: 60, attempt: 1 }),
+      makeScore({ judgeRole: 'J3', value: 70, attempt: 1 }),
+      // Attempt 2: incomplete (J1 only), value = 95
+      makeScore({ judgeRole: 'J1', value: 95, attempt: 2 }),
+    ];
+    const result = computeRunScore(scores, 'cat1', 1, 1);
+    expect(result!.attempt).toBe(1);
+    expect(result!.complete).toBe(true);
+    expect(result!.average).toBe(60);
+  });
+
+  it('ignores scores from different category or athlete', () => {
+    const scores: Score[] = [
+      makeScore({ judgeRole: 'J1', value: 80, categoryId: 'cat2' }),
+      makeScore({ judgeRole: 'J1', value: 90, athleteBib: 99 }),
+    ];
+    const result = computeRunScore(scores, 'cat1', 1, 1);
+    expect(result).toBeNull();
+  });
+});
+
+// ─── computeFinalScore ───────────────────────────────────────────────────────
+
+describe('computeFinalScore', () => {
+  const athlete: Athlete = { bib: 1, name: 'Alice' };
+
+  it('T-S06: both runs complete → best-of-two', () => {
+    const scores: Score[] = [
+      // Run 1: average = 70
+      makeScore({ judgeRole: 'J1', value: 60, run: 1 }),
+      makeScore({ judgeRole: 'J2', value: 70, run: 1 }),
+      makeScore({ judgeRole: 'J3', value: 80, run: 1 }),
+      // Run 2: average = 90
+      makeScore({ judgeRole: 'J1', value: 85, run: 2 }),
+      makeScore({ judgeRole: 'J2', value: 90, run: 2 }),
+      makeScore({ judgeRole: 'J3', value: 95, run: 2 }),
+    ];
+    const result = computeFinalScore(scores, [cat1], athlete);
+    expect(result.total).toBe(90);
+    expect(result.complete).toBe(true);
+    expect(result.categoryScores[0].bestRun).toBe(2);
+  });
+
+  it('T-S07: only run 1 exists → uses run 1', () => {
+    const scores: Score[] = [
+      makeScore({ judgeRole: 'J1', value: 75, run: 1 }),
+      makeScore({ judgeRole: 'J2', value: 80, run: 1 }),
+      makeScore({ judgeRole: 'J3', value: 85, run: 1 }),
+    ];
+    const result = computeFinalScore(scores, [cat1], athlete);
+    expect(result.total).toBe(80);
+    expect(result.categoryScores[0].bestRun).toBe(1);
+    expect(result.categoryScores[0].run2).toBeNull();
+  });
+
+  it('T-S08: no scores → null total', () => {
+    const result = computeFinalScore([], [cat1], athlete);
+    expect(result.total).toBeNull();
+    expect(result.complete).toBe(false);
+  });
+
+  it('sums across multiple categories', () => {
+    const cat2: Category = { id: 'cat2', name: 'Street', athletes: [] };
+    const scores: Score[] = [
+      // Cat1 run 1: average = 80
+      makeScore({ judgeRole: 'J1', value: 80, run: 1, categoryId: 'cat1' }),
+      makeScore({ judgeRole: 'J2', value: 80, run: 1, categoryId: 'cat1' }),
+      makeScore({ judgeRole: 'J3', value: 80, run: 1, categoryId: 'cat1' }),
+      // Cat2 run 1: average = 60
+      makeScore({ judgeRole: 'J1', value: 60, run: 1, categoryId: 'cat2' }),
+      makeScore({ judgeRole: 'J2', value: 60, run: 1, categoryId: 'cat2' }),
+      makeScore({ judgeRole: 'J3', value: 60, run: 1, categoryId: 'cat2' }),
+    ];
+    const result = computeFinalScore(scores, [cat1, cat2], athlete);
+    expect(result.total).toBe(140); // 80 + 60
+  });
+});
+
+// ─── rankAthletes ────────────────────────────────────────────────────────────
+
+describe('rankAthletes', () => {
+  const athletes: Athlete[] = [
+    { bib: 1, name: 'Alice' },
+    { bib: 2, name: 'Bob' },
+    { bib: 3, name: 'Charlie' },
+  ];
+
+  it('T-S09: 3 athletes, distinct scores → ranks 1,2,3', () => {
+    const scores: Score[] = [
+      // Alice: 90
+      makeScore({ athleteBib: 1, judgeRole: 'J1', value: 90, run: 1 }),
+      makeScore({ athleteBib: 1, judgeRole: 'J2', value: 90, run: 1 }),
+      makeScore({ athleteBib: 1, judgeRole: 'J3', value: 90, run: 1 }),
+      // Bob: 80
+      makeScore({ athleteBib: 2, judgeRole: 'J1', value: 80, run: 1 }),
+      makeScore({ athleteBib: 2, judgeRole: 'J2', value: 80, run: 1 }),
+      makeScore({ athleteBib: 2, judgeRole: 'J3', value: 80, run: 1 }),
+      // Charlie: 70
+      makeScore({ athleteBib: 3, judgeRole: 'J1', value: 70, run: 1 }),
+      makeScore({ athleteBib: 3, judgeRole: 'J2', value: 70, run: 1 }),
+      makeScore({ athleteBib: 3, judgeRole: 'J3', value: 70, run: 1 }),
+    ];
+    const ranked = rankAthletes(scores, [cat1], athletes);
+    expect(ranked.map((r) => ({ bib: r.athleteBib, rank: r.rank }))).toEqual([
+      { bib: 1, rank: 1 },
+      { bib: 2, rank: 2 },
+      { bib: 3, rank: 3 },
+    ]);
+  });
+
+  it('T-S10: tied scores → same rank, dense ranking (1,1,2)', () => {
+    const scores: Score[] = [
+      // Alice & Bob both score 80
+      makeScore({ athleteBib: 1, judgeRole: 'J1', value: 80, run: 1 }),
+      makeScore({ athleteBib: 1, judgeRole: 'J2', value: 80, run: 1 }),
+      makeScore({ athleteBib: 1, judgeRole: 'J3', value: 80, run: 1 }),
+      makeScore({ athleteBib: 2, judgeRole: 'J1', value: 80, run: 1 }),
+      makeScore({ athleteBib: 2, judgeRole: 'J2', value: 80, run: 1 }),
+      makeScore({ athleteBib: 2, judgeRole: 'J3', value: 80, run: 1 }),
+      // Charlie: 70
+      makeScore({ athleteBib: 3, judgeRole: 'J1', value: 70, run: 1 }),
+      makeScore({ athleteBib: 3, judgeRole: 'J2', value: 70, run: 1 }),
+      makeScore({ athleteBib: 3, judgeRole: 'J3', value: 70, run: 1 }),
+    ];
+    const ranked = rankAthletes(scores, [cat1], athletes);
+    expect(ranked.map((r) => ({ bib: r.athleteBib, rank: r.rank }))).toEqual([
+      { bib: 1, rank: 1 },
+      { bib: 2, rank: 1 },
+      { bib: 3, rank: 3 },
+    ]);
+  });
+
+  it('T-S11: mix of scored and unscored → unscored at bottom', () => {
+    const scores: Score[] = [
+      // Only Alice scored
+      makeScore({ athleteBib: 1, judgeRole: 'J1', value: 90, run: 1 }),
+      makeScore({ athleteBib: 1, judgeRole: 'J2', value: 90, run: 1 }),
+      makeScore({ athleteBib: 1, judgeRole: 'J3', value: 90, run: 1 }),
+    ];
+    const ranked = rankAthletes(scores, [cat1], athletes);
+    expect(ranked[0].athleteBib).toBe(1);
+    expect(ranked[0].rank).toBe(1);
+    expect(ranked[0].total).toBe(90);
+    // Unscored share the last rank
+    expect(ranked[1].total).toBeNull();
+    expect(ranked[2].total).toBeNull();
+    expect(ranked[1].rank).toBe(ranked[2].rank);
+  });
+
+  it('T-S12: single athlete → rank 1', () => {
+    const single = [{ bib: 1, name: 'Alice' }];
+    const scores: Score[] = [
+      makeScore({ athleteBib: 1, judgeRole: 'J1', value: 88, run: 1 }),
+      makeScore({ athleteBib: 1, judgeRole: 'J2', value: 88, run: 1 }),
+      makeScore({ athleteBib: 1, judgeRole: 'J3', value: 88, run: 1 }),
+    ];
+    const ranked = rankAthletes(scores, [cat1], single);
+    expect(ranked).toHaveLength(1);
+    expect(ranked[0].rank).toBe(1);
+    expect(ranked[0].total).toBe(88);
+  });
+
+  it('T-S13: empty athletes list → empty result', () => {
+    const ranked = rankAthletes([], [cat1], []);
+    expect(ranked).toEqual([]);
+  });
+
+  it('stable sort: tied athletes ordered by bib ascending', () => {
+    const scores: Score[] = [
+      // Both score 80
+      makeScore({ athleteBib: 1, judgeRole: 'J1', value: 80, run: 1 }),
+      makeScore({ athleteBib: 1, judgeRole: 'J2', value: 80, run: 1 }),
+      makeScore({ athleteBib: 1, judgeRole: 'J3', value: 80, run: 1 }),
+      makeScore({ athleteBib: 2, judgeRole: 'J1', value: 80, run: 1 }),
+      makeScore({ athleteBib: 2, judgeRole: 'J2', value: 80, run: 1 }),
+      makeScore({ athleteBib: 2, judgeRole: 'J3', value: 80, run: 1 }),
+    ];
+    const twoAthletes = [athletes[0], athletes[1]];
+    const ranked = rankAthletes(scores, [cat1], twoAthletes);
+    expect(ranked[0].athleteBib).toBe(1);
+    expect(ranked[1].athleteBib).toBe(2);
+  });
+
+  it('rounding: non-trivial averages are rounded to 2 dp', () => {
+    const scores: Score[] = [
+      makeScore({ athleteBib: 1, judgeRole: 'J1', value: 77, run: 1 }),
+      makeScore({ athleteBib: 1, judgeRole: 'J2', value: 78, run: 1 }),
+      makeScore({ athleteBib: 1, judgeRole: 'J3', value: 79, run: 1 }),
+    ];
+    const result = computeRunScore(scores, 'cat1', 1, 1);
+    expect(result!.average).toBe(78); // (77+78+79)/3 = 78
+  });
+});

--- a/__tests__/scoring.test.ts
+++ b/__tests__/scoring.test.ts
@@ -198,7 +198,7 @@ describe('rankAthletes', () => {
     ]);
   });
 
-  it('T-S10: tied scores → same rank, dense ranking (1,1,2)', () => {
+  it('T-S10: tied scores → same rank, standard competition ranking (1,1,3)', () => {
     const scores: Score[] = [
       // Alice & Bob both score 80
       makeScore({ athleteBib: 1, judgeRole: 'J1', value: 80, run: 1 }),

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,16 +1,12 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-
-interface Athlete {
-  bib: number;
-  name: string;
-}
+import type { ClientAthlete } from '@/lib/client-types';
 
 interface Category {
   id: string;
   name: string;
-  athletes: Athlete[];
+  athletes: ClientAthlete[];
 }
 
 export default function AdminPage() {
@@ -23,7 +19,7 @@ export default function AdminPage() {
 
   // Athletes state
   const [expandedCat, setExpandedCat] = useState<string | null>(null);
-  const [athletes, setAthletes] = useState<Athlete[]>([]);
+  const [athletes, setAthletes] = useState<ClientAthlete[]>([]);
   const [athletesLoading, setAthletesLoading] = useState(false);
   const [newBib, setNewBib] = useState<number | ''>('');
   const [newAthleteName, setNewAthleteName] = useState('');

--- a/app/admin/results/page.tsx
+++ b/app/admin/results/page.tsx
@@ -2,41 +2,8 @@
 
 import { useEffect, useState, useCallback, useRef, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
-
-// ─── Types ───────────────────────────────────────────────────────────────────
-
-interface CategorySummary {
-  id: string;
-  name: string;
-  athleteCount: number;
-}
-
-interface RunScoreResult {
-  complete: boolean;
-  average: number | null;
-  attempt: number;
-  scores: Record<string, number | null>;
-}
-
-interface CategoryScoreDetail {
-  categoryId: string;
-  categoryName: string;
-  bestRun: 1 | 2 | null;
-  bestAverage: number | null;
-  bestAttempt: number | null;
-  complete: boolean;
-  run1: RunScoreResult | null;
-  run2: RunScoreResult | null;
-}
-
-interface RankedAthlete {
-  rank: number;
-  athleteBib: number;
-  athleteName: string;
-  complete: boolean;
-  total: number | null;
-  categoryScores: CategoryScoreDetail[];
-}
+import type { RankedAthlete, CategorySummary } from '@/lib/client-types';
+import { thStyle, tdStyle } from '@/lib/client-types';
 
 type ViewMode = 'overall' | 'J1' | 'J2' | 'J3';
 
@@ -204,8 +171,9 @@ function ResultsInner() {
               border: '1px solid #d1d5db',
             }}
           >
-            {VIEW_OPTIONS.map((opt) => {
+            {VIEW_OPTIONS.map((opt, i) => {
               const isActive = viewMode === opt.value;
+              const isLast = i === VIEW_OPTIONS.length - 1;
               return (
                 <button
                   key={opt.value}
@@ -215,7 +183,7 @@ function ResultsInner() {
                     fontSize: '0.9rem',
                     fontWeight: 600,
                     border: 'none',
-                    borderRight: '1px solid #d1d5db',
+                    borderRight: isLast ? 'none' : '1px solid #d1d5db',
                     cursor: 'pointer',
                     background: isActive ? '#2563eb' : '#fff',
                     color: isActive ? '#fff' : '#374151',
@@ -289,7 +257,7 @@ function ResultsInner() {
                     <td style={tdStyle}>{entry.athleteBib}</td>
                     <td style={tdStyle}>
                       {entry.athleteName}
-                      {!entry.complete && entry.total !== null && (
+                      {viewMode === 'overall' && !entry.complete && entry.total !== null && (
                         <span
                           style={{
                             marginLeft: '0.5rem',
@@ -362,16 +330,4 @@ function ResultsInner() {
   );
 }
 
-// ─── Shared styles ───────────────────────────────────────────────────────────
-
-const thStyle: React.CSSProperties = {
-  padding: '0.6rem 0.75rem',
-  textAlign: 'center',
-  fontWeight: 700,
-  color: '#374151',
-};
-
-const tdStyle: React.CSSProperties = {
-  padding: '0.6rem 0.75rem',
-  textAlign: 'left',
-};
+// Table styles imported from @/lib/client-types

--- a/app/api/admin/categories/[categoryId]/athletes/import/route.ts
+++ b/app/api/admin/categories/[categoryId]/athletes/import/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { loadEvent, updateEvent } from '@/lib/store';
 import { validateAdminKey } from '@/lib/auth';
-import type { Athlete } from '@/lib/types';
+import type { Athlete, RouteContext } from '@/lib/types';
 
-type RouteContext = { params: Promise<{ categoryId: string }> };
+type ImportRouteContext = RouteContext<{ categoryId: string }>;
 
 interface CsvError {
   line: number;
@@ -83,7 +83,7 @@ function parseCsv(raw: string): { athletes: { bib: number; name: string; _line: 
  *   - errors: parse errors with line numbers
  *   - athletes: full updated list
  */
-export async function POST(request: NextRequest, context: RouteContext) {
+export async function POST(request: NextRequest, context: ImportRouteContext) {
   const key = request.nextUrl.searchParams.get('key');
   if (!validateAdminKey(key)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/app/api/admin/categories/[categoryId]/athletes/route.ts
+++ b/app/api/admin/categories/[categoryId]/athletes/route.ts
@@ -1,14 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { loadEvent, updateEvent } from '@/lib/store';
 import { validateAdminKey } from '@/lib/auth';
+import type { RouteContext } from '@/lib/types';
 
-type RouteContext = { params: Promise<{ categoryId: string }> };
+type AthleteRouteContext = RouteContext<{ categoryId: string }>;
 
 /**
  * GET /api/admin/categories/[categoryId]/athletes?key=...
  * List athletes for a category, sorted by bib ascending.
  */
-export async function GET(request: NextRequest, context: RouteContext) {
+export async function GET(request: NextRequest, context: AthleteRouteContext) {
   const key = request.nextUrl.searchParams.get('key');
   if (!validateAdminKey(key)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -34,7 +35,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
  * Add an athlete. Body: { bib: number, name: string }
  * Enforces unique bib within the category.
  */
-export async function POST(request: NextRequest, context: RouteContext) {
+export async function POST(request: NextRequest, context: AthleteRouteContext) {
   const key = request.nextUrl.searchParams.get('key');
   if (!validateAdminKey(key)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
@@ -83,7 +84,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
  * DELETE /api/admin/categories/[categoryId]/athletes?key=...&bib=...
  * Remove an athlete by bib number.
  */
-export async function DELETE(request: NextRequest, context: RouteContext) {
+export async function DELETE(request: NextRequest, context: AthleteRouteContext) {
   const key = request.nextUrl.searchParams.get('key');
   if (!validateAdminKey(key)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/app/api/admin/categories/route.ts
+++ b/app/api/admin/categories/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import crypto from 'crypto';
 import { loadEvent, updateEvent } from '@/lib/store';
 import { validateAdminKey } from '@/lib/auth';
+import { DEFAULT_LIVE_STATE } from '@/lib/types';
 import type { Category } from '@/lib/types';
 
 /**
@@ -103,9 +104,8 @@ export async function DELETE(request: NextRequest) {
   if (event.liveState?.activeCategoryId === categoryId) {
     patchData.liveState = {
       ...event.liveState,
+      ...DEFAULT_LIVE_STATE,
       activeCategoryId: null,
-      activeAthleteIndex: 0,
-      activeAttemptNumber: 1,
     };
   }
 

--- a/app/api/admin/categories/route.ts
+++ b/app/api/admin/categories/route.ts
@@ -105,7 +105,6 @@ export async function DELETE(request: NextRequest) {
     patchData.liveState = {
       ...event.liveState,
       ...DEFAULT_LIVE_STATE,
-      activeCategoryId: null,
     };
   }
 

--- a/app/api/admin/create-event/route.ts
+++ b/app/api/admin/create-event/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import crypto from 'crypto';
 import { loadEvent, saveEvent } from '@/lib/store';
 import { generateKey, validateAdminKey } from '@/lib/auth';
+import { DEFAULT_LIVE_STATE } from '@/lib/types';
 import type { EventData } from '@/lib/types';
 
 /**
@@ -70,12 +71,7 @@ export async function POST(request: NextRequest) {
         J3: generateKey(),
       },
       categories: [],
-      liveState: {
-        activeCategoryId: null,
-        activeRun: 1,
-        activeAthleteIndex: 0,
-        activeAttemptNumber: 1,
-      },
+      liveState: { ...DEFAULT_LIVE_STATE },
       scores: [],
       lockedRuns: [],
     };

--- a/app/judge/page.tsx
+++ b/app/judge/page.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect, useState, useCallback, useRef, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
-
-// ─── Types (mirrored from API response shapes) ──────────────────────────────
+import type { RankedAthlete } from '@/lib/client-types';
+import { thStyle, tdStyle } from '@/lib/client-types';
 
 interface LiveState {
   event: string | null;
@@ -12,21 +12,6 @@ interface LiveState {
   athlete: { bib: number; name: string } | null;
   athleteIndex: number;
   athleteCount: number;
-}
-
-interface RankedAthlete {
-  rank: number;
-  athleteBib: number;
-  athleteName: string;
-  total: number | null;
-  categoryScores: {
-    categoryId: string;
-    categoryName: string;
-    bestRun: 1 | 2 | null;
-    bestAverage: number | null;
-    run1: { average: number | null } | null;
-    run2: { average: number | null } | null;
-  }[];
 }
 
 interface LeaderboardResponse {
@@ -300,7 +285,7 @@ function JudgeInner() {
               <tr style={{ borderBottom: '2px solid #e5e7eb' }}>
                 <th style={thStyle}>Rank</th>
                 <th style={{ ...thStyle, textAlign: 'left' }}>Bib</th>
-                <th style={{ ...thStyle, textAlign: 'left' }}>Rider</th>
+                <th style={{ ...thStyle, textAlign: 'left' }}>Athlete</th>
                 <th style={thStyle}>Score</th>
               </tr>
             </thead>
@@ -354,16 +339,4 @@ function JudgeInner() {
   );
 }
 
-// ─── Shared styles ───────────────────────────────────────────────────────────
-
-const thStyle: React.CSSProperties = {
-  padding: '0.5rem 0.6rem',
-  textAlign: 'center',
-  fontWeight: 700,
-  color: '#374151',
-};
-
-const tdStyle: React.CSSProperties = {
-  padding: '0.5rem 0.6rem',
-  textAlign: 'left',
-};
+// Table styles imported from @/lib/client-types

--- a/app/judge/page.tsx
+++ b/app/judge/page.tsx
@@ -1,9 +1,13 @@
 'use client';
 
-import { useEffect, useState, useCallback, useRef, Suspense } from 'react';
+import React, { useEffect, useState, useCallback, useRef, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import type { RankedAthlete } from '@/lib/client-types';
-import { thStyle, tdStyle } from '@/lib/client-types';
+import { thStyle as _thStyle, tdStyle as _tdStyle } from '@/lib/client-types';
+
+// Judge page uses tighter padding than the results page
+const thStyle: React.CSSProperties = { ..._thStyle, padding: '0.5rem 0.6rem' };
+const tdStyle: React.CSSProperties = { ..._tdStyle, padding: '0.5rem 0.6rem' };
 
 interface LiveState {
   event: string | null;

--- a/lib/admin-handler.ts
+++ b/lib/admin-handler.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { loadEvent } from './store';
+import { validateAdminKey } from './auth';
+import type { EventData } from './types';
+
+/**
+ * Wraps an admin API route handler with key validation and event loading.
+ *
+ * If the key is invalid → 401.
+ * If no event exists → 404.
+ * Otherwise calls `handler(request, event, ...rest)` with the loaded event.
+ *
+ * This eliminates the duplicated 6-line auth+load boilerplate across
+ * all admin route handlers.
+ */
+export function withAdminAuth<TArgs extends unknown[]>(
+  handler: (request: NextRequest, event: EventData, ...args: TArgs) => Promise<NextResponse> | NextResponse,
+) {
+  return async (request: NextRequest, ...args: TArgs): Promise<NextResponse> => {
+    const key = request.nextUrl.searchParams.get('key');
+    if (!validateAdminKey(key)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const event = loadEvent();
+    if (!event) {
+      return NextResponse.json({ error: 'No event found' }, { status: 404 });
+    }
+
+    return handler(request, event, ...args);
+  };
+}

--- a/lib/client-types.ts
+++ b/lib/client-types.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared client-side types.
+ *
+ * These mirror the API response shapes so that every client page can import
+ * from one place instead of re-declaring interfaces locally.
+ *
+ * IMPORTANT: This file must not import server-only modules (fs, crypto, etc.)
+ * so that it remains safe for 'use client' pages.
+ */
+
+// Re-export scoring result types that client pages need.
+// These are already defined in lib/scoring.ts and are safe for the client.
+export type {
+  RunScoreResult,
+  CategoryScoreDetail,
+  RankedAthlete,
+} from './scoring';
+
+// ─── Category summary (returned by multiple admin endpoints) ─────────────────
+
+export interface CategorySummary {
+  id: string;
+  name: string;
+  athleteCount: number;
+}
+
+// ─── Simple athlete shape (used in client-side lists) ────────────────────────
+
+export interface ClientAthlete {
+  bib: number;
+  name: string;
+}
+
+// ─── Shared table styles (used by results + judge pages) ─────────────────────
+
+import type React from 'react';
+
+export const thStyle: React.CSSProperties = {
+  padding: '0.6rem 0.75rem',
+  textAlign: 'center',
+  fontWeight: 700,
+  color: '#374151',
+};
+
+export const tdStyle: React.CSSProperties = {
+  padding: '0.6rem 0.75rem',
+  textAlign: 'left',
+};

--- a/lib/scoring.ts
+++ b/lib/scoring.ts
@@ -271,7 +271,7 @@ export function rankAthletes(
   // Sort scored descending by total
   scored.sort((a, b) => (b.total ?? 0) - (a.total ?? 0));
 
-  // Assign dense ranks
+  // Assign standard competition ranks (1,1,3 — not dense 1,1,2)
   const ranked: RankedAthlete[] = [];
   let currentRank = 1;
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -74,6 +74,33 @@ export interface LiveState {
 }
 
 /**
+ * Default LiveState used when creating a new event or resetting state.
+ * Single source of truth — import this instead of hardcoding the shape.
+ */
+export const DEFAULT_LIVE_STATE: LiveState = {
+  activeCategoryId: null,
+  activeRun: 1,
+  activeAthleteIndex: 0,
+  activeAttemptNumber: 1,
+};
+
+/**
+ * Payload accepted by PUT /api/admin/live.
+ * Extends Partial<LiveState> with control fields for lock/unlock and re-run.
+ */
+export interface LiveUpdatePayload extends Partial<LiveState> {
+  lock?: boolean;
+  rerun?: boolean;
+}
+
+/**
+ * Shared route context type for dynamic route segments (Next.js App Router).
+ */
+export type RouteContext<T extends Record<string, string> = Record<string, string>> = {
+  params: Promise<T>;
+};
+
+/**
  * EventData represents a persistent event record.
  *
  * @property id         - Unique identifier (non-empty string)

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
       "devDependencies": {
         "@types/node": "^20",
         "@types/react": "19.2.14",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -26,6 +27,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@img/colour": {
@@ -494,6 +937,13 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@next/env": {
       "version": "15.5.12",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.12.tgz",
@@ -628,6 +1078,363 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -636,6 +1443,31 @@
       "dependencies": {
         "tslib": "^2.8.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.19.33",
@@ -655,6 +1487,127 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/caniuse-lite": {
@@ -677,6 +1630,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -698,6 +1661,118 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/nanoid": {
@@ -770,11 +1845,42 @@
         }
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/postcss": {
       "version": "8.4.31",
@@ -823,6 +1929,51 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/scheduler": {
@@ -889,6 +2040,13 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -897,6 +2055,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
@@ -919,6 +2091,50 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -947,6 +2163,205 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "next": "^15.0.0",
@@ -16,6 +18,7 @@
   "devDependencies": {
     "@types/node": "^20",
     "@types/react": "19.2.14",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.0.18"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['__tests__/**/*.test.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+});


### PR DESCRIPTION
﻿## US-REF-00: Codebase Health Baseline

Repo-wide audit and consolidation to establish a clean foundation before new feature work.

### What changed (20 files: 4 new, 16 modified)

**Duplication removal:**
- Eliminated duplicated interfaces across 4 client pages  shared `lib/client-types.ts`
- Removed all `as unknown as` type casts (live page lock/rerun calls)
- Unified LiveState defaults  `DEFAULT_LIVE_STATE` constant (single source of truth)
- Shared table styles (`thStyle`/`tdStyle`) extracted; judge page overrides preserved
- `RouteContext<T>` generic replaces per-route local type aliases

**Patterns standardized:**
- `withAdminAuth(handler)` wrapper for admin routes (applied to results route; pattern ready for remaining routes)
- `LiveUpdatePayload` interface for type-safe live update calls
- `Cache-Control: no-store` on results endpoint
- "Rider"  "Athlete" naming across UI
- Provisional badge hidden in per-judge view (was incorrectly shown)
- Border overlap fix on results view switcher buttons

**Test coverage added:**
- Vitest 4.0 configured (`npm test` / `npm run test:watch`)
- 18 scoring tests: `computeRunScore`, `computeFinalScore`, `rankAthletes`
- 13 auth+store tests: `generateKey`, `validateAdminKey`, `validateJudgeKey`, `loadEvent`, `saveEvent`, `updateEvent`
- 31 unit tests all passing

**Review fixes (post-review):**
- Restored judge page original table padding (0.5rem 0.6rem) via override
- Removed redundant `activeCategoryId: null` in categories DELETE handler
- Fixed misleading "dense ranking" label  "standard competition ranking (1,1,3)"

**Docs:**
- ARCHITECTURE.md updated with Health Baseline notes (standardized, not-refactored, recommendations)
- STATUS.md updated with detailed summary

### Testing

- `npm run build`  clean, 0 errors
- `npm test`  31/31 pass
- 26-scenario manual regression  all pass (event lifecycle, scoring, leaderboard, per-judge view, best-of-two-runs, re-run attempts, lock enforcement, exports)
- No regressions found

### Follow-up (backlog)

- Apply `withAdminAuth` to remaining 6 admin routes
